### PR TITLE
Add repository URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "way-cooler-bg"
 version = "0.2.0"
 authors = ["Timidger <APragmaticPlace@gmail.com>"]
 description = "Background program for Way Cooler"
+repository = "https://github.com/way-cooler/way-cooler-bg"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
so people are able to get here from https://crates.io/crates/way-cooler